### PR TITLE
Added PlayApp view state persistence

### DIFF
--- a/PlayCover/ViewModel/PlayAppVM.swift
+++ b/PlayCover/ViewModel/PlayAppVM.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Combine
 
 class PlayAppVM: ObservableObject {
     @Published var app: PlayApp

--- a/PlayCover/ViewModel/PlayAppVM.swift
+++ b/PlayCover/ViewModel/PlayAppVM.swift
@@ -1,0 +1,26 @@
+//
+//  PlayAppVM.swift
+//  PlayCover
+//
+//  Created by Adam Chen JingFan on 4/7/24.
+//
+
+import SwiftUI
+import Combine
+
+class PlayAppVM: ObservableObject {
+    @Published var app: PlayApp
+    @Published var showSettings = false
+    @Published var showClearPreferencesAlert = false
+    @Published var showClearPlayChainAlert = false
+    @Published var showStartingProgress = false
+    @Published var showImportSuccess = false
+    @Published var showImportFail = false
+    @Published var showChangeGenshinAccount = false
+    @Published var showStoreGenshinAccount = false
+    @Published var showDeleteGenshinAccount = false
+
+    init(app: PlayApp) {
+        self.app = app
+    }
+}

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -25,6 +25,7 @@ struct PlayAppView: View {
                 if viewModel.app.info.bundleIdentifier == "com.miHoYo.GenshinImpact" {
                     removeTwitterSessionCookie()
                 }
+                // Launch the app from a separate thread (allow us to Sayori it if needed)
                 Task(priority: .userInitiated) {
                     if !viewModel.app.isStarting {
                         viewModel.showStartingProgress = true

--- a/PlayCover/Views/App Views/PlayAppView.swift
+++ b/PlayCover/Views/App Views/PlayAppView.swift
@@ -7,100 +7,86 @@ import SwiftUI
 import DataCache
 
 struct PlayAppView: View {
-
     @Binding var selectedBackgroundColor: Color
     @Binding var selectedTextColor: Color
     @Binding var selected: PlayApp?
+    @Binding var isList: Bool
 
-    @State var app: PlayApp
-    @State var isList: Bool
-
-    @State private var showSettings = false
-    @State private var showClearPreferencesAlert = false
-    @State private var showClearPlayChainAlert = false
-    @State private var showStartingProgress = false
-
-    @State var showImportSuccess = false
-    @State var showImportFail = false
-
-    @State private var showChangeGenshinAccount = false
-    @State private var showStoreGenshinAccount = false
-    @State private var showDeleteGenshinAccount = false
+    @StateObject var viewModel: PlayAppVM
 
     var body: some View {
         PlayAppConditionalView(selectedBackgroundColor: $selectedBackgroundColor,
                                selectedTextColor: $selectedTextColor,
                                selected: $selected,
-                               showStartingProgress: $showStartingProgress,
-                               app: app,
+                               showStartingProgress: $viewModel.showStartingProgress,
+                               app: viewModel.app,
                                isList: isList)
             .gesture(TapGesture(count: 2).onEnded {
-                if app.info.bundleIdentifier == "com.miHoYo.GenshinImpact" {
+                if viewModel.app.info.bundleIdentifier == "com.miHoYo.GenshinImpact" {
                     removeTwitterSessionCookie()
                 }
-                // Launch the app from a separate thread (allow us to Sayori it if needed)
                 Task(priority: .userInitiated) {
-                    if !app.isStarting {
-                        showStartingProgress = true
-                        await app.launch()
-                        showStartingProgress = false
+                    if !viewModel.app.isStarting {
+                        viewModel.showStartingProgress = true
+                        await viewModel.app.launch()
+                        viewModel.showStartingProgress = false
                     }
                 }
             })
             .simultaneousGesture(TapGesture().onEnded {
-                selected = app
+                selected = viewModel.app
             })
             .contextMenu {
                 Button(action: {
-                    showSettings.toggle()
+                    viewModel.showSettings.toggle()
                 }, label: {
                     Text("playapp.settings")
                 })
                 Button(action: {
-                    app.openAppCache()
+                    viewModel.app.openAppCache()
                 }, label: {
                     Text("playapp.openCache")
                 })
                 Button(action: {
-                    app.showInFinder()
+                    viewModel.app.showInFinder()
                 }, label: {
                     Text("playapp.showInFinder")
                 })
                 Divider()
                 Group {
                     Button(action: {
-                        app.keymapping.importKeymap { result in
+                        viewModel.app.keymapping.importKeymap { result in
                             if result {
-                                showImportSuccess.toggle()
+                                viewModel.showImportSuccess.toggle()
                             } else {
-                                showImportFail.toggle()
+                                viewModel.showImportFail.toggle()
                             }
                         }
                     }, label: {
                         Text("playapp.importKm")
                     })
                     Button(action: {
-                        app.keymapping.exportKeymap()
+                        viewModel.app.keymapping.exportKeymap()
                     }, label: {
                         Text("playapp.exportKm")
                     })
                 }
                 Group {
-                    if app.info.bundleIdentifier.contains("GenshinImpact")
-                        || app.info.bundleIdentifier.contains("Yuanshen") {
+                    if viewModel.app.info.bundleIdentifier.contains("GenshinImpact")
+                        || viewModel.app.info.bundleIdentifier.contains("Yuanshen") {
                         Divider()
                         Button(action: {
-                            showStoreGenshinAccount.toggle()
+                            viewModel.showStoreGenshinAccount.toggle()
                         }, label: {
                             Text("playapp.storeCurrentAccount")
                         })
                         Button(action: {
-                            showChangeGenshinAccount.toggle()
+                            viewModel.showChangeGenshinAccount.toggle()
                         }, label: {
                             Text("playapp.activateAccount")
                         })
                         Button(action: {
-                            showDeleteGenshinAccount.toggle()
+                            viewModel.showDeleteGenshinAccount.toggle()
                         }, label: {
                             Text("playapp.deleteAccount")
                         })
@@ -110,17 +96,17 @@ struct PlayAppView: View {
                 Group {
                     Button(action: {
                         selected = nil
-                        Task { await Uninstaller.clearCachePopup(app) }
+                        Task { await Uninstaller.clearCachePopup(viewModel.app) }
                     }, label: {
                         Text("playapp.clearCache")
                     })
                     Button(action: {
-                        showClearPreferencesAlert.toggle()
+                        viewModel.showClearPreferencesAlert.toggle()
                     }, label: {
                         Text("playapp.clearPreferences")
                     })
                     Button(action: {
-                        showClearPlayChainAlert.toggle()
+                        viewModel.showClearPlayChainAlert.toggle()
                     }, label: {
                         Text("playapp.clearPlayChain")
                     })
@@ -128,46 +114,46 @@ struct PlayAppView: View {
                 Divider()
                 Button(action: {
                     selected = nil
-                    Task { await Uninstaller.uninstallPopup(app) }
+                    Task { await Uninstaller.uninstallPopup(viewModel.app) }
                 }, label: {
                     Text("playapp.delete")
                 })
             }
-            .sheet(isPresented: $showChangeGenshinAccount) {
-                ChangeGenshinAccountView(app: app)
+            .sheet(isPresented: $viewModel.showChangeGenshinAccount) {
+                ChangeGenshinAccountView(app: viewModel.app)
             }
-            .sheet(isPresented: $showStoreGenshinAccount) {
-                StoreGenshinAccountView(app: app)
+            .sheet(isPresented: $viewModel.showStoreGenshinAccount) {
+                StoreGenshinAccountView(app: viewModel.app)
             }
-            .sheet(isPresented: $showDeleteGenshinAccount) {
+            .sheet(isPresented: $viewModel.showDeleteGenshinAccount) {
                 DeleteGenshinAccountView()
             }
-            .alert("alert.app.preferences", isPresented: $showClearPreferencesAlert) {
+            .alert("alert.app.preferences", isPresented: $viewModel.showClearPreferencesAlert) {
                 Button("button.Proceed", role: .destructive) {
-                    deletePreferences(app: app.info.bundleIdentifier)
-                    showClearPreferencesAlert.toggle()
+                    deletePreferences(app: viewModel.app.info.bundleIdentifier)
+                    viewModel.showClearPreferencesAlert.toggle()
                 }
                 Button("button.Cancel", role: .cancel) { }
             }
-            .alert("alert.app.clearPlayChain", isPresented: $showClearPlayChainAlert) {
+            .alert("alert.app.clearPlayChain", isPresented: $viewModel.showClearPlayChainAlert) {
                 Button("button.Proceed", role: .destructive) {
-                    app.clearPlayChain()
-                    showClearPlayChainAlert.toggle()
+                    viewModel.app.clearPlayChain()
+                    viewModel.showClearPlayChainAlert.toggle()
                 }
                 Button("button.Cancel", role: .cancel) { }
             }
-            .onChange(of: showImportSuccess) { _ in
+            .onChange(of: viewModel.showImportSuccess) { _ in
                 ToastVM.shared.showToast(
                     toastType: .notice,
                     toastDetails: NSLocalizedString("alert.kmImported", comment: ""))
             }
-            .onChange(of: showImportFail) { _ in
+            .onChange(of: viewModel.showImportFail) { _ in
                 ToastVM.shared.showToast(
                     toastType: .error,
                     toastDetails: NSLocalizedString("alert.errorImportKm", comment: ""))
             }
-            .sheet(isPresented: $showSettings) {
-                AppSettingsView(viewModel: AppSettingsVM(app: app))
+            .sheet(isPresented: $viewModel.showSettings) {
+                AppSettingsView(viewModel: AppSettingsVM(app: viewModel.app))
             }
     }
 


### PR DESCRIPTION
For PlayCover PR [#1517](https://github.com/PlayCover/PlayCover/pull/1517)

Addressing the following issue:

> This works perfectly with a showStartingProgress variable, but when isList is changed during starting, showStartingProgress is reset to false.
> 
> I then decide to rely on app.isStarting and update showStartingProgress from it, but something I don't understand happens: app.isStarting also resets to false. This not only lead to the not showing of the progress view when switching between List view and Grid view, but also makes the app can be launched multiple times during launching.

The issue comes from the fact that, a new instance of `PlayAppView` is created when the view mode changes, resulting in a loss of state. Therefore, `PlayAppVM` viewmodel is introduced to separate the states from the view, so when the view gets destroyed and created (switching from Grid to List, vise versa), the states will be consistent.